### PR TITLE
feat: add llava local provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,12 @@
   4) uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
   5) http://localhost:8000/docs
 - Docker: backend/에서 `docker compose up --build`
+
+## LLaVA Local Provider
+
+Set environment variables when running the backend to use a local LLaVA model:
+
+- `ANALYSIS_PROVIDER=llava_local`
+- `LLAVA_MODEL_PATH` – path to the downloaded LLaVA model and processor.
+- `LLAVA_DEVICE` – optional torch device (e.g. `cpu`, `cuda`, `cuda:0`).
+  Defaults to GPU if available.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -86,7 +86,7 @@ def get_analysis_provider():
         return SimpleNamespace(analyze=analyze)
     elif p == "llava_local":
         from app.providers.llava_local import query_llm
-        return SimpleNamespace(analyze=lambda prompt, img: query_llm(prompt, img))
+        return SimpleNamespace(analyze=query_llm)
     else:
         from app.providers.vision_stub import analyze
         return SimpleNamespace(analyze=analyze)

--- a/backend/app/providers/llava_local.py
+++ b/backend/app/providers/llava_local.py
@@ -1,0 +1,29 @@
+import os
+import io
+import torch
+from PIL import Image
+from transformers import AutoProcessor, LlavaForConditionalGeneration
+
+# Path to local LLaVA model weights
+MODEL_PATH = os.environ.get("LLAVA_MODEL_PATH")
+if not MODEL_PATH:
+    raise EnvironmentError("LLAVA_MODEL_PATH is not set")
+
+# Optional device override; default to CUDA when available
+DEVICE = os.getenv("LLAVA_DEVICE", "cuda" if torch.cuda.is_available() else "cpu")
+DTYPE = torch.float16 if "cuda" in DEVICE else torch.float32
+
+# Load processor and model once at import time
+PROCESSOR = AutoProcessor.from_pretrained(MODEL_PATH)
+MODEL = LlavaForConditionalGeneration.from_pretrained(
+    MODEL_PATH, torch_dtype=DTYPE
+).to(DEVICE)
+
+
+def query_llm(prompt: str, image_bytes: bytes) -> str:
+    """Run a prompt+image pair through the local LLaVA model."""
+    image = Image.open(io.BytesIO(image_bytes)).convert("RGB")
+    inputs = PROCESSOR(text=prompt, images=image, return_tensors="pt").to(DEVICE, dtype=DTYPE)
+    with torch.inference_mode():
+        output_ids = MODEL.generate(**inputs, max_new_tokens=256)
+    return PROCESSOR.batch_decode(output_ids, skip_special_tokens=True)[0]


### PR DESCRIPTION
## Summary
- add local LLaVA provider loading model from `LLAVA_MODEL_PATH`
- hook provider into analysis selection logic
- document environment variables for the provider

## Testing
- `python -m py_compile backend/app/providers/llava_local.py backend/app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3a8ab8ccc8332808928247a44de8a