### PR TITLE
Remove duplicate FastAPI app initialization

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,10 +10,6 @@ from app.core.paths import (
 from fastapi import UploadFile, File, Form
 
 
-
-app = FastAPI(title="Design Evaluation Vertical Slice", version="0.1.0")
-app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
-
 def init_db():
     ensure_dirs()
     conn = sqlite3.connect(DB_PATH)


### PR DESCRIPTION
## Summary
- Remove redundant FastAPI app instantiation before lifespan setup
- Keep single app with lifespan and CORS middleware

## Testing
- `PYTHONPATH=backend pytest -q`
- `PYTHONPATH=backend python - <<'PY'
import asyncio
import fastapi.dependencies.utils as fud
fud.ensure_multipart_is_installed = lambda: None
from app import main
from types import SimpleNamespace
main.get_analysis_provider = lambda: SimpleNamespace(analyze=lambda prompt, img: 'ok')
print('Before startup:', main.ANALYZER)
asyncio.run(main.app.router.startup())
print('After startup:', main.ANALYZER)
asyncio.run(main.app.router.shutdown())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b3a8b52f688332a61f2a19ec260241