### PR TITLE
feat: add LLM analysis upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Thumbs.db
 # Frontend
 frontend/node_modules/
 frontend/dist/
+frontend/tsconfig.tsbuildinfo

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -7,6 +7,15 @@ async function j(method: string, path: string, body?: any) {
 export const api = {
   upload: (p:{title:string;author_id:string;asset_url?:string;meta?:any}) => j("POST","/uploads",p),
   analyze: (submission_id:string) => j("POST","/analyze",{submission_id}),
+  analyzeLlm: async (file: File, prompt: string, submissionId: string) => {
+    const fd = new FormData();
+    fd.append("file", file);
+    fd.append("prompt", prompt);
+    fd.append("submission_id", submissionId);
+    const r = await fetch(`${API_BASE}/analyze-llm`, { method: "POST", body: fd });
+    if (!r.ok) throw new Error(`POST /analyze-llm -> ${r.status}`);
+    return r.json();
+  },
   search: (q:string) => j("POST","/search-guideline",{award_id:"aw_2025_kda", query:q}),
   rubric: () => j("GET","/rubrics/aw_2025_kda/1.0.0"),
   evaluate: (rec:any) => j("POST","/evaluate",rec),


### PR DESCRIPTION
## Summary
- add `analyzeLlm` helper to post FormData to `/analyze-llm`
- expose new UI to upload a design image and show LLM findings with loading/error states

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b3a8be00d883328160a077eae0704b