### PR TITLE
feat: log evaluation data for training

### DIFF
--- a/backend/app/core/paths.py
+++ b/backend/app/core/paths.py
@@ -10,9 +10,11 @@ DATA_DIR = Path(os.getenv("DATA_DIR", APP_DIR / "data"))
 SCHEMAS_DIR = Path(os.getenv("SCHEMAS_DIR", APP_DIR / "schemas"))
 SEEDS_DIR = Path(os.getenv("SEEDS_DIR", APP_DIR / "seeds"))
 DB_PATH = Path(os.getenv("DB_PATH", DATA_DIR / "slice.db"))
+DATASET_DIR = Path(os.getenv("DATASET_DIR", DATA_DIR / "dataset"))
 
 GUIDELINE_FILE = Path(os.getenv("GUIDELINE_FILE", SEEDS_DIR / "guidelines" / "kda_2025_guideline.md"))
 RUBRIC_FILE = Path(os.getenv("RUBRIC_FILE", SEEDS_DIR / "rubrics" / "kda_2025_v1.json"))
 
 def ensure_dirs():
     DATA_DIR.mkdir(parents=True, exist_ok=True)
+    DATASET_DIR.mkdir(parents=True, exist_ok=True)

--- a/backend/app/schemas/training_dataset.schema.sql
+++ b/backend/app/schemas/training_dataset.schema.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS training_dataset (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  submission_id TEXT NOT NULL,
+  image_path TEXT NOT NULL,
+  evaluation_json TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS ix_training_submission ON training_dataset (submission_id);

--- a/scripts/export_dataset.py
+++ b/scripts/export_dataset.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+import argparse, json, sqlite3, sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "backend"))
+from app.core.paths import DB_PATH
+
+def main():
+    parser = argparse.ArgumentParser(description="Export training dataset as JSONL")
+    parser.add_argument("--out", default="training_dataset.jsonl", help="Output JSONL file path")
+    args = parser.parse_args()
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.execute("SELECT image_path, evaluation_json FROM training_dataset ORDER BY id")
+    rows = cur.fetchall()
+    conn.close()
+    out_path = Path(args.out)
+    with out_path.open("w", encoding="utf-8") as f:
+        for img, ev_json in rows:
+            f.write(json.dumps({"image_path": img, "evaluation": json.loads(ev_json)}, ensure_ascii=False) + "\n")
+    print(f"Exported {len(rows)} rows to {out_path}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- persist training samples with image paths and evaluation results
- add dataset export script for fine-tuning

## Testing
- `python -m py_compile backend/app/core/paths.py backend/app/main.py scripts/export_dataset.py`
- `python scripts/export_dataset.py --out /tmp/ds.jsonl`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3a8cd46a48332a02b3466ef9fd61b