### PR TITLE
feat: add feedback submission flow

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -222,6 +222,16 @@ def evaluate(record: dict):
     log_evidence("evaluate", sid, record)
     return {"ok": True}
 
+
+@app.post("/feedback")
+def feedback(record: dict):
+    """Receive manual feedback on a submission and store it in the evidence ledger."""
+    sid = record.get("submission_id", "unknown")
+    uid = record.get("user_id")
+    payload = {"text": record.get("text"), "rating": record.get("rating")}
+    log_evidence("feedback", sid, payload, uid)
+    return {"ok": True}
+
 @app.get("/report/{submission_id}")
 def report(submission_id: str):
     conn = sqlite3.connect(DB_PATH)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import api from "./api";
 import { RubricDSL, AnalyzeResponse, ReportEvent } from "./types";
 import Findings from "./components/Findings";
 import RubricForm from "./components/RubricForm";
+import FeedbackForm from "./components/FeedbackForm";
 
 export default function App(){
   const [sid, setSid] = useState<string>("");
@@ -37,6 +38,7 @@ export default function App(){
       </div>
       {findings ? (<div className="card"><b>2) 자동 분석 결과</b><Findings items={findings.findings} /></div>) : null}
       {rubric && sid ? (<RubricForm rubric={rubric} submissionId={sid} onSubmitted={loadReport} />) : null}
+      {sid ? (<FeedbackForm submissionId={sid} onSubmitted={loadReport} />) : null}
       {sid ? (<div className="card">
         <div className="row" style={{justifyContent:"space-between"}}><b>3) Evidence Report</b><button className="btn" onClick={loadReport}>새로고침</button></div>
         <div className="muted">upload/analyze/evaluate 로그가 순서대로 보입니다.</div>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -10,6 +10,7 @@ export const api = {
   search: (q:string) => j("POST","/search-guideline",{award_id:"aw_2025_kda", query:q}),
   rubric: () => j("GET","/rubrics/aw_2025_kda/1.0.0"),
   evaluate: (rec:any) => j("POST","/evaluate",rec),
+  feedback: (p:{submission_id:string;user_id:string;text:string;rating:number}) => j("POST","/feedback",p),
   report: (sid:string) => j("GET",`/report/${sid}`)
 };
 export default api;

--- a/frontend/src/components/FeedbackForm.tsx
+++ b/frontend/src/components/FeedbackForm.tsx
@@ -1,0 +1,30 @@
+import { useState } from "react";
+import api from "../api";
+
+type Props = { submissionId: string; onSubmitted: () => void };
+
+export default function FeedbackForm({ submissionId, onSubmitted }: Props) {
+  const [userId, setUserId] = useState("u_demo_user");
+  const [rating, setRating] = useState(5);
+  const [text, setText] = useState("");
+
+  const submit = async () => {
+    await api.feedback({ submission_id: submissionId, user_id: userId, rating, text });
+    setText("");
+    onSubmitted();
+  };
+
+  return (
+    <div className="card">
+      <div className="row" style={{ justifyContent: "space-between" }}>
+        <b>Feedback</b>
+      </div>
+      <div className="list">
+        <input placeholder="User ID" value={userId} onChange={e => setUserId(e.target.value)} />
+        <input type="number" min={1} max={5} value={rating} onChange={e => setRating(Number(e.target.value))} />
+        <textarea rows={3} placeholder="Your feedback" value={text} onChange={e => setText(e.target.value)} />
+        <button className="btn" onClick={submit}>Submit</button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -9,3 +9,4 @@
 export type AnalyzeFinding = { region:{x:number;y:number;w:number;h:number}; label:string; confidence:number; explanation:string; citations?:string[]; };
 export type AnalyzeResponse = { findings: AnalyzeFinding[]; model_version:string; prompt_snapshot:string; };
 export type ReportEvent = { kind: string; at: string; payload: any };
+export type FeedbackPayload = { submission_id: string; user_id: string; rating: number; text: string };


### PR DESCRIPTION
## Summary
- add `/feedback` endpoint to log user feedback in evidence ledger
- add API helper and React form to capture feedback from reviewers
- display feedback entries in evidence report

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3a8d1e7908332a686e0dc47c1cf98