### PR TITLE
feat: enrich evidence logs with raw output and image references

### DIFF
--- a/backend/app/schemas/evidence_ledger.schema.sql
+++ b/backend/app/schemas/evidence_ledger.schema.sql
@@ -4,7 +4,9 @@
   submission_id TEXT NOT NULL,
   user_id TEXT,
   at TEXT NOT NULL,
-  payload_json TEXT NOT NULL
+  payload_json TEXT NOT NULL,
+  raw_output TEXT,
+  image TEXT
 );
 CREATE INDEX IF NOT EXISTS ix_evidence_submission ON evidence_ledger (submission_id);
 CREATE INDEX IF NOT EXISTS ix_evidence_kind ON evidence_ledger (kind);


### PR DESCRIPTION
## Summary
- capture raw model output and image path in `log_evidence`
- extend evidence ledger schema to store raw_output and image columns
- add `/dataset/export` endpoint to collect `{image, findings, corrections}` for training

## Testing
- `python -m py_compile backend/app/main.py`
- `python - <<'PY'
import sys
sys.path.append('backend')
from app.main import init_db, uploads, analyze, evaluate, dataset_export, load_guideline_chunks
from app.main import CHUNKS
init_db(); CHUNKS[:] = load_guideline_chunks()
up = uploads({'asset_url': 'img1.png'}); sid = up['submission_id']
analyze({'submission_id': sid}); evaluate({'submission_id': sid, 'corrections': {'label': 'Fixed'}})
print(dataset_export())
PY`
- `pip install httpx` *(fails: Could not find a version that satisfies the requirement httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d1e96b308332b3ce51cc700b634b