### PR TITLE
feat: add judge review step

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import api from "./api";
 import { RubricDSL, AnalyzeResponse, ReportEvent } from "./types";
 import Findings from "./components/Findings";
 import RubricForm from "./components/RubricForm";
+import JudgeReview from "./components/JudgeReview";
 
 export default function App(){
   const [sid, setSid] = useState<string>("");
@@ -36,9 +37,10 @@ export default function App(){
         {sid ? <div className="row">submission_id: <span className="mono pill">{sid}</span></div> : null}
       </div>
       {findings ? (<div className="card"><b>2) 자동 분석 결과</b><Findings items={findings.findings} /></div>) : null}
+      {findings && sid ? (<JudgeReview submissionId={sid} initialFindings={findings.findings} onSubmitted={loadReport} />) : null}
       {rubric && sid ? (<RubricForm rubric={rubric} submissionId={sid} onSubmitted={loadReport} />) : null}
       {sid ? (<div className="card">
-        <div className="row" style={{justifyContent:"space-between"}}><b>3) Evidence Report</b><button className="btn" onClick={loadReport}>새로고침</button></div>
+        <div className="row" style={{justifyContent:"space-between"}}><b>4) Evidence Report</b><button className="btn" onClick={loadReport}>새로고침</button></div>
         <div className="muted">upload/analyze/evaluate 로그가 순서대로 보입니다.</div>
         <div style={{marginTop:8}} />
         {events.length ? events.map((e,i)=>(

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -10,6 +10,7 @@ export const api = {
   search: (q:string) => j("POST","/search-guideline",{award_id:"aw_2025_kda", query:q}),
   rubric: () => j("GET","/rubrics/aw_2025_kda/1.0.0"),
   evaluate: (rec:any) => j("POST","/evaluate",rec),
+  review: (p:{submission_id:string; findings:any; note?:string}) => j("POST","/review",p),
   report: (sid:string) => j("GET",`/report/${sid}`)
 };
 export default api;

--- a/frontend/src/components/JudgeReview.tsx
+++ b/frontend/src/components/JudgeReview.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import api from "../api";
+import { AnalyzeFinding } from "../types";
+
+interface Props {
+  submissionId: string;
+  initialFindings: AnalyzeFinding[];
+  onSubmitted?: () => void;
+}
+
+export default function JudgeReview({ submissionId, initialFindings, onSubmitted }: Props) {
+  const [items, setItems] = useState<AnalyzeFinding[]>(initialFindings);
+  const [note, setNote] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const update = (index:number, field:keyof AnalyzeFinding, value:any)=>{
+    setItems(fs => fs.map((f,i)=> i===index ? { ...f, [field]: value } : f));
+  };
+
+  const submit = async () => {
+    setBusy(true);
+    try {
+      await api.review({ submission_id: submissionId, findings: items, note });
+      alert("Review submitted");
+      onSubmitted?.();
+    } catch (e) {
+      alert("Submit failed");
+    }
+    setBusy(false);
+  };
+
+  if(!items?.length) return null;
+  return (<div className="card">
+    <div className="row" style={{justifyContent:"space-between"}}>
+      <b>3) Judge Review</b>
+      <button className="btn" onClick={submit} disabled={busy}>Submit to agency</button>
+    </div>
+    <div className="list">
+      {items.map((f,i)=>(
+        <div className="card" key={i} style={{background:"#0f142b"}}>
+          <div><input value={f.label} onChange={e=>update(i,'label',e.target.value)} style={{width:"100%"}} /></div>
+          <textarea rows={3} value={f.explanation} onChange={e=>update(i,'explanation',e.target.value)} style={{width:"100%",marginTop:4}} />
+        </div>
+      ))}
+      <div><label className="muted">Notes</label>
+        <textarea rows={3} style={{width:"100%"}} value={note} onChange={e=>setNote(e.target.value)} />
+      </div>
+    </div>
+  </div>);
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="vite/client" />
+export {};


### PR DESCRIPTION
## Summary
- add JudgeReview component for human edits and notes
- support `/review` API to send curated findings
- plug JudgeReview into analysis flow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3d1eb73c88332b617113b0af1b457