### PR TITLE
feat: enable llava image chat

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -29,8 +29,21 @@ upload: (p: {
     title: string;
     author_id: string;
     asset_url?: string;
+    file?: File;
     meta?: any;
-  }) => j<{ submission_id: string; created_at: string }>("POST", "/uploads", p),
+  }) => {
+    if (p.file) {
+      const form = new FormData();
+      form.append("title", p.title);
+      form.append("author_id", p.author_id);
+      form.append("file", p.file);
+      return fetch("/uploads", { method: "POST", body: form }).then((r) => {
+        if (!r.ok) throw new Error("upload failed");
+        return r.json();
+      });
+    }
+    return j<{ submission_id: string; created_at: string }>("POST", "/uploads", p);
+  },
 
   analyze: (submission_id: string) =>
     j<AnalyzeResponse>("POST", "/analyze", { submission_id }),


### PR DESCRIPTION
## Summary
- allow uploading image files and sending them to Ollama LLaVA in `/uploads` and `/chat`
- add frontend workflow to upload an image and ask a prompt
- support multipart uploads in frontend API client

## Testing
- `pytest` *(fails: command not found)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b3f45695208332b54cf684ba11a014