### PR TITLE
Handle Ollama offline errors

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -187,8 +187,8 @@ async def chat(payload: ChatRequest) -> ChatResponse:
     image_b64 = row[0]
     try:
         raw = await generate(message, "llava:7b", images=[image_b64], stream=False)
-    except HTTPException:
-        raise
+    except HTTPException as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     answer = raw.get("response", "").strip()
     resp = ChatResponse(
         answer=answer,


### PR DESCRIPTION
## Summary
- log unreachable Ollama URL and report descriptive HTTP error
- propagate generate() HTTP errors through chat endpoint
- show chat errors in frontend so users know when the model is offline

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b40d1860e48332bbf27e8edf5199b3