### PR TITLE
Add python-multipart dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn[standard]
 httpx
+python-multipart


### PR DESCRIPTION
## Summary
- add python-multipart to backend requirements

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement python-multipart (from versions: none))*

------
https://chatgpt.com/codex/tasks/task_e_68b4159ae6e48332996bb357a5f2f5e4