### PR TITLE
Enforce image type and size limits during upload

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -132,7 +132,11 @@ async def uploads(
     )
     image_b64: str | None = None
     if file is not None:
+        if file.content_type not in {"image/jpeg", "image/png"}:
+            raise HTTPException(400, "Only JPEG/PNG images allowed")
         content = await file.read()
+        if len(content) > 2 * 1024 * 1024:
+            raise HTTPException(413, "Image too large")
         image_b64 = base64.b64encode(content).decode("utf-8")
     payload = {
         "title": title,


### PR DESCRIPTION
## Summary
- validate uploaded files are JPEG or PNG and under 2 MB
- only store base64 image when validations pass

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4192a0dec83328362a06a56c63e15