### PR TITLE
Validate image uploads and surface errors

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,6 +12,7 @@
  .list{display:grid;gap:8px}
  .pill{background:#21305e;color:#a9c6ff;border:1px solid #2c3b72;border-radius:999px;padding:4px 10px;font-size:12px}
  .muted{opacity:.7}.mono{font-family:ui-monospace,Consolas,monospace}
+ .error{color:#ff6b6b;margin-top:8px}
 </style></head><body>
 <div id="root"></div><script type="module" src="/src/main.tsx"></script>
 </body></html>


### PR DESCRIPTION
## Summary
- add file type and size validation when selecting images
- separate api.upload and api.chat in try/catch blocks and expose errors in the UI
- style new `.error` class for visible feedback

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b41b708d9c8332bd3fccf4db495371