### PR TITLE
Propagate upload errors and surface in UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,19 +38,23 @@ export default function App(){
     }
     let submissionId = "";
     try {
-      const u = await api.upload({ title: "Demo", author_id: "u_demo", file: imageFile });
+      const u = await api.upload({
+        title: "Demo",
+        author_id: "u_demo",
+        file: imageFile,
+      });
       submissionId = u.submission_id;
       setSid(submissionId);
-    } catch (err: any) {
-      setError(err.message);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
       setBusy(false);
       return;
     }
     try {
       const c = await api.chat(submissionId, question);
       setAnswer(c.answer);
-    } catch (err: any) {
-      setError(err.message);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
     } finally {
       setBusy(false);
     }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -39,10 +39,15 @@ upload: (p: {
       form.append("title", p.title);
       form.append("author_id", p.author_id);
       form.append("file", p.file);
-      return fetch(API_BASE + "/uploads", { method: "POST", body: form }).then((r) => {
-        if (!r.ok) throw new Error("upload failed");
-        return r.json();
-      });
+      return fetch(API_BASE + "/uploads", { method: "POST", body: form }).then(
+        async (r) => {
+          if (!r.ok) {
+            const msg = await r.text();
+            throw new Error(msg || "upload failed");
+          }
+          return r.json();
+        },
+      );
     }
     return j<{ submission_id: string; created_at: string }>("POST", "/uploads", p);
   },


### PR DESCRIPTION
## Summary
- return server-provided text when uploads fail
- surface upload and chat failures via error state in App

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Module '../types' has no exported member 'EvaluateRequest')*


------
https://chatgpt.com/codex/tasks/task_e_68b42e8b3ce88332906bc959d788fc54