### PR TITLE
fix frontend api base env and types

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -8,7 +8,10 @@ import type {
   Assignment,
 } from "./types";
 
-const API_BASE = import.meta.env.VITE_API_URL ?? "http://localhost:8000";
+const API_BASE =
+  import.meta.env.VITE_API_URL ??
+  import.meta.env.VITE_API_BASE ??
+  "http://localhost:8000";
 
 const j = async <T>(
   method: string,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -13,3 +13,23 @@ export type Project = { project_id:number; name:string; created_at:string };
 export type Submission = { submission_id:number; project_id?:number; title:string; created_at:string };
 export type Judge = { judge_id:number; name:string; created_at:string };
 export type Assignment = { assignment_id:number; submission_id:number; judge_id:number; score?:number|null; created_at:string };
+
+export type EvaluateRequest = {
+  submission_id: string;
+  judge_id: string;
+  rubric_version: string;
+  scores: Array<{
+    criteria_id: string;
+    score: number;
+    reason?: string;
+    citation_ids?: string[];
+    checks?: Record<string, any>;
+  }>;
+  model_suggestions?: Array<{
+    criteria_id?: string;
+    suggested_score?: number;
+    explanation?: string;
+    citation_ids?: string[];
+  }>;
+  submitted_at?: string;
+};


### PR DESCRIPTION
## Summary
- support both VITE_API_URL and VITE_API_BASE so frontend can reach backend
- add EvaluateRequest type to satisfy TypeScript build

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4311067888332ad40921edf066c4b