### PR TITLE
Improve Ollama timeout and frontend API base handling

### DIFF
--- a/backend/app/ollama_client.py
+++ b/backend/app/ollama_client.py
@@ -25,7 +25,10 @@ async def generate(prompt: str, model: str, **kwargs: Any) -> Dict[str, Any]:
     url = f"{OLLAMA_BASE_URL}/api/generate"
     payload: Dict[str, Any] = {"model": model, "prompt": prompt, **kwargs}
     try:
-        async with httpx.AsyncClient(timeout=10) as client:
+        # llava:7b can take a while on first load; extend timeout so the
+        # frontend doesn't see spurious errors while the model warms up.
+        timeout = httpx.Timeout(60.0, connect=10.0)
+        async with httpx.AsyncClient(timeout=timeout) as client:
             response = await client.post(url, json=payload)
             response.raise_for_status()
     except httpx.ConnectError as exc:

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -8,22 +8,32 @@ import type {
   Assignment,
 } from "./types";
 
-const API_BASE = import.meta.env.VITE_API_URL ?? "http://localhost:8000";
+const API_BASE = (
+  import.meta.env.VITE_API_URL ??
+  import.meta.env.VITE_API_BASE ??
+  "http://localhost:8000"
+).replace(/\/+$/, "");
 
 const j = async <T>(
   method: string,
   path: string,
   body?: unknown,
 ): Promise<T> => {
-  const res = await fetch(API_BASE + path, {
-    method,
-    headers: body ? { "Content-Type": "application/json" } : undefined,
-    body: body ? JSON.stringify(body) : undefined,
-  });
-  if (!res.ok) {
-    throw new Error(await res.text());
+  try {
+    const res = await fetch(API_BASE + path, {
+      method,
+      headers: body ? { "Content-Type": "application/json" } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    if (!res.ok) {
+      throw new Error(await res.text());
+    }
+    return res.json() as Promise<T>;
+  } catch (err) {
+    throw new Error(
+      `API request failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
-  return res.json() as Promise<T>;
 };
 
 export const api = {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -13,3 +13,23 @@ export type Project = { project_id:number; name:string; created_at:string };
 export type Submission = { submission_id:number; project_id?:number; title:string; created_at:string };
 export type Judge = { judge_id:number; name:string; created_at:string };
 export type Assignment = { assignment_id:number; submission_id:number; judge_id:number; score?:number|null; created_at:string };
+
+export type EvaluateRequest = {
+  submission_id: string;
+  judge_id: string;
+  rubric_version: string;
+  scores: Array<{
+    criteria_id: string;
+    score: number;
+    reason?: string;
+    citation_ids?: string[];
+    checks?: Record<string, any>;
+  }>;
+  model_suggestions?: Array<{
+    criteria_id?: string;
+    suggested_score?: number;
+    explanation?: string;
+    citation_ids?: string[];
+  }>;
+  submitted_at?: string;
+};


### PR DESCRIPTION
## Summary
- extend Ollama client's timeout to tolerate slow `llava:7b` model startups
- sanitize frontend API base URL and improve network error reporting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `pytest` *(0 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b4311067888332ad40921edf066c4b