### PR TITLE
feat: add structured parsing and retries for LLM responses

### DIFF
--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,4 +1,6 @@
 """Pydantic schemas for request/response models."""
+from pydantic import BaseModel, Field
+
 from .models import (
     UploadRequest,
     UploadResponse,
@@ -14,6 +16,26 @@ from .models import (
     ModelSuggestion,
 )
 
+
+class LLMChatResponse(BaseModel):
+    """Structured output from a chat generation."""
+
+    answer: str
+    citations: list[str] = Field(default_factory=list)
+
+
+class StructuredError(BaseModel):
+    """Error payload returned to clients when parsing fails."""
+
+    error: str
+
+
+class AgentAnswer(BaseModel):
+    """Structured answer returned from the LangChain agent."""
+
+    answer: str
+
+
 __all__ = [
     "UploadRequest",
     "UploadResponse",
@@ -27,4 +49,7 @@ __all__ = [
     "EvaluateResponse",
     "EvaluationScore",
     "ModelSuggestion",
+    "LLMChatResponse",
+    "StructuredError",
+    "AgentAnswer",
 ]

--- a/backend/app/test_generation.py
+++ b/backend/app/test_generation.py
@@ -1,0 +1,49 @@
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+from langchain.output_parsers import PydanticOutputParser
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.providers import Provider, generate_structured  # noqa:E402
+from app.schemas import LLMChatResponse  # noqa:E402
+
+
+class FakeProvider(Provider):
+    def __init__(self, outputs):
+        self.outputs = outputs
+        self.calls = 0
+
+    async def generate(self, prompt: str, model: str, **kwargs):
+        out = self.outputs[self.calls]
+        self.calls += 1
+        return {"response": out}
+
+
+@pytest.mark.asyncio
+async def test_generate_structured_valid():
+    provider = FakeProvider(['{"answer": "hi", "citations": []}'])
+    parser = PydanticOutputParser(pydantic_object=LLMChatResponse)
+    result, raw = await generate_structured(provider, "q", "m", parser)
+    assert result.answer == "hi"
+    assert provider.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_structured_invalid():
+    provider = FakeProvider(['oops', 'bad', 'still'])
+    parser = PydanticOutputParser(pydantic_object=LLMChatResponse)
+    with pytest.raises(ValidationError):
+        await generate_structured(provider, "q", "m", parser)
+    assert provider.calls == 3
+
+
+@pytest.mark.asyncio
+async def test_generate_structured_retry_success():
+    provider = FakeProvider(['oops', '{"answer": "ok", "citations": []}'])
+    parser = PydanticOutputParser(pydantic_object=LLMChatResponse)
+    result, raw = await generate_structured(provider, "q", "m", parser)
+    assert result.answer == "ok"
+    assert provider.calls == 2


### PR DESCRIPTION
## Summary
- define Pydantic v2 schemas for structured outputs and errors
- parse agent and provider generations with LangChain `PydanticOutputParser`
- retry on `ValidationError` and raise structured errors on failure
- add unit tests for generation success, failure, and retry

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'langchain')*


------
https://chatgpt.com/codex/tasks/task_e_68b45d700a208332af819b9c2a486f14